### PR TITLE
Add custom 'Token' header due to apache authorization limitation

### DIFF
--- a/OAuth2/Request.php
+++ b/OAuth2/Request.php
@@ -159,6 +159,8 @@ class Request implements RequestInterface
 
                 if (isset($requestHeaders['Authorization'])) {
                     $authorizationHeader = trim($requestHeaders['Authorization']);
+                } elseif (isset($requestHeaders['Token'])) {
+                    $authorizationHeader = trim($requestHeaders['Token']);
                 }
             }
 


### PR DESCRIPTION
Apache2 doesn't by default forward the Authorization header to PHP, to work around this, I have added a custom `Token` header that serves the same purpose but doesn't require any Apache2 reconfiguration.