### PR TITLE
Add `course_info.php`, improve `user_info.php` processing logic

### DIFF
--- a/course_info.php
+++ b/course_info.php
@@ -1,0 +1,60 @@
+<?php
+
+require_once '../../config.php';
+require_once __DIR__ . '/lib.php';
+
+\core\session\manager::write_close();
+
+$server = oauth_get_server();
+$request = OAuth2\Request::createFromGlobals();
+
+if (!$server->verifyResourceRequest($request)) {
+    return send_invalid_response(400, array('other' => array('cause' => 'invalid_approval')));
+}
+
+$token = $server->getAccessTokenData($request);
+if (!isset($token['user_id']) || empty($token['user_id'])) {
+    return send_invalid_response(401, array('other' => array('cause' => 'invalid_token')));
+}
+
+$userid = $token['user_id'];
+
+// Validate scope is correct
+if (!$server->verifyResourceRequest($request, $response, 'course_info')) {
+    return send_invalid_response(403, array('relateduserid' => $userid, 'other' => array('cause' => 'insufficient_scope')));
+}
+
+// Validate user exists
+$user = $DB->get_record_sql('SELECT id FROM {user} WHERE id=:user_id', ['user_id' => $userid]);
+if (!$user) {
+    return send_invalid_response(404, array('other' => array('cause' => 'user_not_found')));
+}
+
+$course_id = $request->query('course_id');
+$external_url = $request->query('external_url');
+if ($course_id == null && $external_url == null) {
+    return send_invalid_response(400, array('other' => array('cause' => 'missing_course_id')));
+}
+
+// Get course information from external_url
+$course = $course_id != null ?
+    $DB->get_record_sql('SELECT id, fullname, shortname FROM {course} WHERE id=:course_id', ['course_id' => $course_id]) :
+    $DB->get_record_sql('SELECT c.id as id, c.fullname as fullname, c.shortname as shortname FROM {course} as c INNER JOIN {url} as u on c.id=u.course WHERE '.$DB->sql_like('externalurl', ':external_url'), ['external_url' => $external_url]);
+
+$course_id = $course->id;
+
+// Ensure user is enrolled in course
+$course_enrollment = $DB->get_record_sql(
+    'SELECT u.id, c.id FROM mdl_user u INNER JOIN mdl_user_enrolments ue ON ue.userid = u.id INNER JOIN mdl_enrol e ON e.id = ue.enrolid INNER JOIN mdl_course c ON e.courseid = c.id WHERE u.id=:user_id AND c.id=:course_id', ['user_id' => $userid, 'course_id' => $course_id]
+);
+if (!$course_enrollment) {
+    return send_invalid_response(404, array('other' => array('cause' => 'user_not_enrolled_in_course')));
+}
+
+// Log user details
+$logparams = array('userid' => $userid);
+$event = \local_oauth\event\user_info_request::create($logparams);
+$event->trigger();
+
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($course);

--- a/lang/ca/local_oauth.php
+++ b/lang/ca/local_oauth.php
@@ -32,6 +32,7 @@ $string['delete_error'] = 'Error eliminant el client';
 
 $string['scope_login'] = 'Informació de login';
 $string['scope_user_info'] = 'Informació del perfil d\'usuari/ària';
+$string['scope_course_info'] = 'Informació genèrica del curs';
 
 $string['event_user_not_granted'] = 'Usuari/ària no autoritzat';
 $string['event_user_granted'] = 'Usuari/ària autoritzat';

--- a/lang/en/local_oauth.php
+++ b/lang/en/local_oauth.php
@@ -32,6 +32,7 @@ $string['delete_error'] = 'Error occurred deleting client';
 
 $string['scope_login'] = 'Login Information (email, login time, etc.)';
 $string['scope_user_info'] = 'User Profile Information (name, country, etc.)';
+$string['scope_course_info'] = 'Generic Course Information';
 
 $string['event_user_not_granted'] = 'User not granted';
 $string['event_user_granted'] = 'User granted';

--- a/lang/es/local_oauth.php
+++ b/lang/es/local_oauth.php
@@ -32,6 +32,7 @@ $string['delete_error'] = 'Se ha producido un error eliminando el cliente';
 
 $string['scope_login'] = 'Información de login';
 $string['scope_user_info'] = 'Información del perfil de usuario';
+$string['scope_course_info'] = 'Información genérica del curso';
 
 $string['event_user_not_granted'] = 'Usuario no autorizado';
 $string['event_user_granted'] = 'Usuario autorizado';

--- a/lib.php
+++ b/lib.php
@@ -68,3 +68,10 @@ function authorize_user_scope($userid, $clientid, $scope = false) {
 
     $DB->insert_record('oauth_user_auth_scopes', $record);
 }
+
+function send_invalid_response($statusCode, $logparams) {
+    $event = \local_oauth\event\user_info_request_failed::create($logparams);
+    $event->trigger();
+    $response = new OAuth2\Response(array('message' => OAuth2\Response::$statusTexts[$statusCode]), $statusCode);
+    $response->send();
+}

--- a/login.php
+++ b/login.php
@@ -29,7 +29,7 @@ $clientid = required_param('client_id', PARAM_RAW);
 $responsetype = required_param('response_type', PARAM_RAW);
 $scope = optional_param('scope', false, PARAM_TEXT);
 $state = optional_param('state', false, PARAM_TEXT);
-$redirect_uri = urlencode(optional_param('redirect_uri', false, PARAM_URL));
+$redirect_uri = urlencode(optional_param('redirect_uri', false, PARAM_RAW));
 
 $url = $CFG->wwwroot.'/local/oauth/login.php?client_id='.$clientid.'&response_type='.$responsetype;
 

--- a/user_info.php
+++ b/user_info.php
@@ -6,52 +6,38 @@ require_once __DIR__.'/lib.php';
 \core\session\manager::write_close();
 
 $server = oauth_get_server();
-if (!$server->verifyResourceRequest(OAuth2\Request::createFromGlobals())) {
-    $logparams = array('other' => array('cause' => 'invalid_approval'));
-    $event = \local_oauth\event\user_info_request_failed::create($logparams);
-    $event->trigger();
+$request = OAuth2\Request::createFromGlobals();
 
-    $server->getResponse()->send();
-    die();
+if (!$server->verifyResourceRequest($request)) {
+    return send_invalid_response(400, array('other' => array('cause' => 'invalid_approval')));
 }
 
-
-$token = $server->getAccessTokenData(OAuth2\Request::createFromGlobals());
-if (isset($token['user_id']) && !empty($token['user_id'])) {
-
-    $user = $DB->get_record_sql('SELECT id,auth,username,idnumber,firstname,lastname,email,lang,city,country,phone1,address,description FROM {user} WHERE id=:id', ['id' => $token['user_id']]);
-    $tags = $DB->get_records_sql('SELECT ti.tagid as id, t.rawname as tag FROM {tag_instance} as ti INNER JOIN {tag} as t on t.id=ti.tagid WHERE itemtype=\'user\' AND itemid=:user_id;', ['user_id' => $token['user_id']]);
-
-    if (!$user) {
-        $logparams = array('other' => array('cause' => 'user_not_found'));
-        $event = \local_oauth\event\user_info_request_failed::create($logparams);
-        $event->trigger();
-
-        $response->send();
-    }
-
-    $request = OAuth2\Request::createFromGlobals();
-    $response = new OAuth2\Response();
-    $scopeRequired = 'user_info';
-    if (!$server->verifyResourceRequest($request, $response, $scopeRequired)) {
-        $logparams = array('relateduserid' => $user->id, 'other' => array('cause' => 'insufficient_scope'));
-        $event = \local_oauth\event\user_info_request_failed::create($logparams);
-        $event->trigger();
-
-          // if the scope required is different from what the token allows, this will send a "401 insufficient_scope" error
-          $response->send();
-    }
-
-    $logparams = array('userid' => $user->id);
-    $event = \local_oauth\event\user_info_request::create($logparams);
-    $event->trigger();
-    $user->tags = array_values($tags);
-    header('Content-Type: application/json; charset=utf-8');
-    echo json_encode($user);
-} else {
-    $logparams = array('other' => array('cause' => 'invalid_token'));
-    $event = \local_oauth\event\user_info_request_failed::create($logparams);
-    $event->trigger();
-
-    $server->getResponse()->send();
+$token = $server->getAccessTokenData($request);
+if (!isset($token['user_id']) || empty($token['user_id'])) {
+    return send_invalid_response(401, array('other' => array('cause' => 'invalid_token')));
 }
+
+$userid = $token['user_id'];
+
+// Validate scope is correct
+if (!$server->verifyResourceRequest($request, $response, 'user_info')) {
+    return send_invalid_response(403, array('relateduserid' => $userid, 'other' => array('cause' => 'insufficient_scope')));
+}
+
+// Validate user exists
+$user = $DB->get_record_sql('SELECT id,auth,username,idnumber,firstname,lastname,email,lang,city,country,phone1,address,description FROM {user} WHERE id=:user_id', ['user_id' => $userid]);
+if (!$user) {
+    return send_invalid_response(404, array('other' => array('cause' => 'user_not_found')));
+}
+
+$tags = $DB->get_records_sql('SELECT ti.tagid as id, t.rawname as tag FROM {tag_instance} as ti INNER JOIN {tag} as t on t.id=ti.tagid WHERE itemtype=\'user\' AND itemid=:user_id;', ['user_id' => $userid]);
+$user->tags = array_values($tags);
+
+// Log user details
+$logparams = array('userid' => $userid);
+$event = \local_oauth\event\user_info_request::create($logparams);
+$event->trigger();
+
+// Send Response
+header('Content-Type: application/json; charset=utf-8');
+echo json_encode($user);


### PR DESCRIPTION
### Current buglist

- [x] Scope form page shows `[[scope_course_info]]` - should be value from lang file.
- [x] Multiple scope OAuth requests cause redirect to only include `code` when first accepting the permissions - possibly the fact that scopes are separated by spaces causing issues, will need further investigation.